### PR TITLE
chore: set up Vite build for GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log*
+dist
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # Learn-French
+
+Prototype React app for learning French.
+
+## Development
+
+Install dependencies and start the dev server:
+
+```bash
+npm install
+npm run dev
+```
+
+Build for production (used by GitHub Pages):
+
+```bash
+npm run build
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Learn French</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/main.jsx"></script>
+  </body>
+</html>

--- a/main.jsx
+++ b/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './app_react_style_apple_learn_french.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "learn-french",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "framer-motion": "^10.16.1",
+    "lucide-react": "^0.308.0",
+    "recharts": "^2.9.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  base: '/Learn-French/'
+});


### PR DESCRIPTION
## Summary
- add Vite config with React plugin and base path for GitHub Pages
- provide entry HTML and main.jsx to mount existing app
- document build and dev instructions

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@vitejs%2fplugin-react)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689646627df48320824e67366e773037