### PR TITLE
fix: remove .npmrc and use npm install

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Configure Pages
         uses: actions/configure-pages@v5
 
-- name: Install
-  run: npm install
+      - name: Install
+        run: npm install
 
       - name: Build
         run: npm run build

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-registry=https://registry.npmjs.org/
-proxy=null
-https-proxy=null


### PR DESCRIPTION
## Summary
- remove project-specific .npmrc to avoid private registry requirement
- fix GitHub Pages workflow to use `npm install`

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68966b529820832086aabfdf63053942